### PR TITLE
refactor: type name

### DIFF
--- a/components/listings/ListingCard.tsx
+++ b/components/listings/ListingCard.tsx
@@ -2,12 +2,12 @@ import Image from 'next/image';
 import { useRouter } from 'next/router';
 
 import { useCountries } from '@/hooks/useCountries';
-import { TypeSafeListing } from '@/types';
+import { SafeTypeListing } from '@/types';
 
 import FavoriteButton from '../FavoriteButton';
 
 interface ListingCardProps {
-  listing: TypeSafeListing;
+  listing: SafeTypeListing;
 }
 
 const ListingCard = ({ listing }: ListingCardProps) => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,7 @@ import EmptyState from '@/components/EmptyState';
 import ListingCard from '@/components/listings/ListingCard';
 
 import { prisma } from '@/libs/prismadb';
-import { TypeSafeListing } from '@/types';
+import { SafeTypeListing } from '@/types';
 import { GetStaticProps } from 'next';
 
 export const getStaticProps: GetStaticProps = async () => {
@@ -21,7 +21,7 @@ export const getStaticProps: GetStaticProps = async () => {
 };
 
 interface HomeProps {
-  listings: TypeSafeListing[];
+  listings: SafeTypeListing[];
 }
 
 const Home = ({ listings }: HomeProps) => {

--- a/pages/listings/[listingId].tsx
+++ b/pages/listings/[listingId].tsx
@@ -3,10 +3,10 @@ import { GetStaticPaths } from 'next';
 import Container from '@/components/Container';
 import ListingHead from '@/components/listings/ListingHead';
 import { prisma } from '@/libs/prismadb';
-import { TypeSafeListing } from '@/types';
+import { SafeTypeListing } from '@/types';
 
 interface ListingPageProps {
-  listing: TypeSafeListing;
+  listing: SafeTypeListing;
 }
 
 interface IParams {

--- a/types/index.ts
+++ b/types/index.ts
@@ -7,11 +7,11 @@ export type CountrySelectValue = {
   value: string;
 };
 
-export type TypeSafeListing = Omit<Listing, 'createdAt'> & {
+export type SafeTypeListing = Omit<Listing, 'createdAt'> & {
   createdAt: string;
 };
 
-export type TypeSafeUser = Omit<
+export type SafeTypeUser = Omit<
   User,
   'createdAt' | 'updatedAt' | 'emailVerified'
 > & {


### PR DESCRIPTION
to avoid confusion with actual term type-safe

safe in this context means that it is a safe type for Next.js to process (when using functions like getStaticProps) because it cannot serialize datetime objects