### PR TITLE
ci: remove postinstall script

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -31,8 +31,6 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install dependencies
-        env:
-          DATABASE_URL: ${{ secrets.DB_BASE_URL }}-${{ github.run_id }}
         run: npm ci
 
       - name: Cypress run

--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -30,8 +30,6 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install dependencies
-        env:
-          DATABASE_URL: ${{ secrets.DB_BASE_URL }}-${{ github.run_id }}
         run: npm ci
       - name: Install Playwright
         run: npx playwright install --with-deps

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "build-storybook": "storybook build",
     "cypress:open": "env-cmd -f .env.test cypress open",
     "cypress:start": "npm run build:test && start-server-and-test 'npm run start:test' 3000 'npm run cypress:open'",
-    "cypress:run": "npm run build:test && start-server-and-test 'npm run start:test' 3000 'env-cmd -f .env.test cypress run'",
-    "postinstall": "npx prisma db push --force-reset"
+    "cypress:run": "npm run build:test && start-server-and-test 'npm run start:test' 3000 'env-cmd -f .env.test cypress run'"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --cache --fix",


### PR DESCRIPTION
Move `npx prisma db push` to vercel custom build command

This way it should still work on production, but now the postinstall script won't run for ci tests.

Originally, it would force reset db for test dbs, but it also meant that every deploy would reset production data.