### PR TITLE
ci: remove test workflow triggers on push to main

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -1,7 +1,5 @@
 name: 'Cypress Tests'
 on:
-  push:
-    branches: ['main']
   pull_request:
     branches: ['main']
   workflow_dispatch:

--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -1,7 +1,5 @@
 name: 'Storybook Tests'
 on:
-  push:
-    branches: ['main']
   pull_request:
     branches: ['main']
   workflow_dispatch:


### PR DESCRIPTION
Tests already being run in pr, so unnecessary to run again in main