### PR TITLE
feat: add blur placeholder to listing image

### DIFF
--- a/src/components/listings/ListingCard.tsx
+++ b/src/components/listings/ListingCard.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 
 import { SafeTypeListing, SafeTypeReservation } from '@/types';
 
+import { shimmer, toBase64 } from '@/libs/nextBlurImg';
 import { differenceInDays, format } from 'date-fns';
 import { useCallback, useMemo } from 'react';
 import Button from '../Button';
@@ -85,7 +86,10 @@ const ListingCard = ({
             src={listing.imageSrc}
             alt="Listing"
             sizes="300px"
-            priority
+            placeholder="blur"
+            blurDataURL={`data:image/svg+xml;base64,${toBase64(
+              shimmer(700, 475)
+            )}`}
           />
           <div className="absolute right-3 top-3">
             <FavoriteButton listingId={listing.id} />

--- a/src/components/listings/ListingHead.tsx
+++ b/src/components/listings/ListingHead.tsx
@@ -1,3 +1,4 @@
+import { shimmer, toBase64 } from '@/libs/nextBlurImg';
 import Image from 'next/image';
 import FavoriteButton from '../FavoriteButton';
 import Heading from '../Heading';
@@ -33,7 +34,10 @@ const ListingHead = ({
           fill
           className="object-cover"
           alt="Car"
-          priority
+          placeholder="blur"
+          blurDataURL={`data:image/svg+xml;base64,${toBase64(
+            shimmer(700, 475)
+          )}`}
           sizes="100vw"
         />
         <div className="absolute right-5 top-5">

--- a/src/components/listings/ListingHead.tsx
+++ b/src/components/listings/ListingHead.tsx
@@ -38,7 +38,7 @@ const ListingHead = ({
           blurDataURL={`data:image/svg+xml;base64,${toBase64(
             shimmer(700, 475)
           )}`}
-          sizes="100vw"
+          sizes="(max-width: 1400px) 100vw, 80vw"
         />
         <div className="absolute right-5 top-5">
           <FavoriteButton listingId={id} />

--- a/src/libs/nextBlurImg.ts
+++ b/src/libs/nextBlurImg.ts
@@ -1,0 +1,20 @@
+// Reference: https://github.com/vercel/next.js/blob/canary/examples/image-component/pages/shimmer.tsx
+// colors have been edited
+export const shimmer = (w: number, h: number) => `
+<svg width="${w}" height="${h}" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <linearGradient id="g">
+      <stop stop-color="#ccc" offset="20%" />
+      <stop stop-color="#bbb" offset="50%" />
+      <stop stop-color="#ccc" offset="70%" />
+    </linearGradient>
+  </defs>
+  <rect width="${w}" height="${h}" fill="#ccc" />
+  <rect id="r" width="${w}" height="${h}" fill="url(#g)" />
+  <animate xlink:href="#r" attributeName="x" from="-${w}" to="${w}" dur="1s" repeatCount="indefinite"  />
+</svg>`;
+
+export const toBase64 = (str: string) =>
+  typeof window === 'undefined'
+    ? Buffer.from(str).toString('base64')
+    : window.btoa(str);


### PR DESCRIPTION
It should help performance by lazy loading images instead of using priority prop.

At the same time, it will give the user some feedback by giving them a skeleton indicating something is loading.